### PR TITLE
[MIGSOFTWAR-28698] - Fix for test_dhcp_relay_v4_mvlan.py failure

### DIFF
--- a/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
@@ -65,7 +65,7 @@ def add_dhcp_relay(vid, dhcp_relay_ips, db, ip_version):
     table_name = DHCP_RELAY_TABLE if ip_version == 6 else VLAN_TABLE
     dhcp_servers_str = DHCPV6_SERVERS if ip_version == 6 else DHCPV4_SERVERS
     vlan_name = "Vlan{}".format(vid)
-    if ip_version == IPV4:
+    if ip_version == IPV4 and check_sonic_dhcpv4_relay_flag(db):
        dhcp_table_name = DHCPV4_RELAY_TABLE
        dhcpv4_servers_str = DHCPV4_RELAY_TBL_SERVERS
     ctx = click.get_current_context()
@@ -74,7 +74,7 @@ def add_dhcp_relay(vid, dhcp_relay_ips, db, ip_version):
 
     # It's unnecessary for DHCPv6 Relay to verify entry exist
     check_config_exist = True if ip_version == 4 else False
-    if ip_version == IPV4:
+    if ip_version == IPV4 and check_sonic_dhcpv4_relay_flag(db):
        dhcpv4_servers, v4_table = get_dhcp_servers(db, vlan_name, ctx, dhcp_table_name, dhcpv4_servers_str, check_config_exist)
     else:
        dhcp_servers, table = get_dhcp_servers(db, vlan_name, ctx, table_name, dhcp_servers_str, check_config_exist)
@@ -85,7 +85,7 @@ def add_dhcp_relay(vid, dhcp_relay_ips, db, ip_version):
         if dhcp_relay_ip in added_ips:
             ctx.fail("Find duplicate DHCP relay ip {} in add list".format(dhcp_relay_ip))
 
-        if ip_version == IPV4:
+        if ip_version == IPV4 and check_sonic_dhcpv4_relay_flag(db):
             if dhcp_relay_ip in dhcpv4_servers:
                 ctx.fail("{} is already a DHCPv4 relay for {}".format(dhcp_relay_ip, vlan_name))
             dhcpv4_servers.append(dhcp_relay_ip)
@@ -96,7 +96,7 @@ def add_dhcp_relay(vid, dhcp_relay_ips, db, ip_version):
         added_ips.append(dhcp_relay_ip)
 
     # for IPv4, we will add same entry to DHCPV4_RELAY table also
-    if ip_version == IPV4:
+    if ip_version == IPV4 and check_sonic_dhcpv4_relay_flag(db):
         v4_table[dhcpv4_servers_str] = dhcpv4_servers
         db.cfgdb.set_entry(dhcp_table_name, vlan_name, v4_table)
     else:
@@ -114,13 +114,13 @@ def del_dhcp_relay(vid, dhcp_relay_ips, db, ip_version):
     table_name = DHCP_RELAY_TABLE if ip_version == 6 else VLAN_TABLE
     dhcp_servers_str = DHCPV6_SERVERS if ip_version == 6 else DHCPV4_SERVERS
     vlan_name = "Vlan{}".format(vid)
-    if ip_version == IPV4:
+    if ip_version == IPV4 and check_sonic_dhcpv4_relay_flag(db):
        dhcp_table_name = DHCPV4_RELAY_TABLE
        dhcpv4_servers_str = DHCPV4_RELAY_TBL_SERVERS
     ctx = click.get_current_context()
     # Verify ip addresses are valid
     validate_ips(ctx, dhcp_relay_ips, ip_version)
-    if ip_version == IPV4:
+    if ip_version == IPV4 and check_sonic_dhcpv4_relay_flag(db):
        dhcpv4_servers, v4_table = get_dhcp_servers(db, vlan_name, ctx, dhcp_table_name, dhcpv4_servers_str)
     else:
        dhcp_servers, table = get_dhcp_servers(db, vlan_name, ctx, table_name, dhcp_servers_str)
@@ -131,7 +131,7 @@ def del_dhcp_relay(vid, dhcp_relay_ips, db, ip_version):
         if dhcp_relay_ip in removed_ips:
             ctx.fail("Find duplicate DHCP relay ip {} in del list".format(dhcp_relay_ip))
 
-        if ip_version == IPV4:
+        if ip_version == IPV4 and check_sonic_dhcpv4_relay_flag(db):
             if dhcp_relay_ip in dhcpv4_servers:
                 dhcpv4_servers.remove(dhcp_relay_ip)
                 removed_ips.append(dhcp_relay_ip)
@@ -145,7 +145,7 @@ def del_dhcp_relay(vid, dhcp_relay_ips, db, ip_version):
               ctx.fail("{} is not a DHCP relay for {}".format(dhcp_relay_ip, vlan_name))
 
     # for IPv4, we will remove same entry from DHCPV4_RELAY table also
-    if ip_version == IPV4:
+    if ip_version == IPV4 and check_sonic_dhcpv4_relay_flag(db):
        if len(dhcpv4_servers) == 0:
            db.cfgdb.set_entry(dhcp_table_name, vlan_name, None)
        else:

--- a/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
@@ -48,11 +48,11 @@ def get_dhcp_servers(db, vlan_name, ctx, table_name, dhcp_servers_str, check_is_
     return dhcp_servers, table
 
 
-def restart_dhcp_relay_service(db):
+def restart_dhcp_relay_service(db, ip_version):
     """
     Restart dhcp_relay service
     """
-    if(check_sonic_dhcpv4_relay_flag(db)):
+    if(ip_version == IPV4 and check_sonic_dhcpv4_relay_flag(db)):
         # if 'has_sonic_dhcpv4_relay' flag is present in FEATURE['dhcp_relay] and is 'true'
         return
     click.echo("Restarting DHCP relay service...")
@@ -105,7 +105,7 @@ def add_dhcp_relay(vid, dhcp_relay_ips, db, ip_version):
 
     click.echo("Added DHCP relay address [{}] to {}".format(",".join(dhcp_relay_ips), vlan_name))
     try:
-        restart_dhcp_relay_service(db)
+        restart_dhcp_relay_service(db, ip_version)
     except SystemExit as e:
         ctx.fail("Restart service dhcp_relay failed with error {}".format(e))
 
@@ -163,7 +163,7 @@ def del_dhcp_relay(vid, dhcp_relay_ips, db, ip_version):
 
     click.echo("Removed DHCP relay address [{}] from {}".format(",".join(dhcp_relay_ips), vlan_name))
     try:
-        restart_dhcp_relay_service(db)
+        restart_dhcp_relay_service(db, ip_version)
     except SystemExit as e:
         ctx.fail("Restart service dhcp_relay failed with error {}".format(e))
 
@@ -586,6 +586,9 @@ def add_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
 
     ctx = click.get_current_context()
     added_servers = []
+    dhcpv4_relay_servers = []
+
+
 
     # Verify vlan is valid
     vlan_name = 'Vlan{}'.format(vid)
@@ -608,6 +611,7 @@ def add_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
                     click.echo("Cannot change dhcp_relay configuration when dhcp_server feature is enabled")
                     return
                 dhcp_servers.append(ip_addr)
+                dhcpv4_relay_servers.append(ip_addr)
             else:
                 dhcpv6_servers.append(ip_addr)
             added_servers.append(ip_addr)
@@ -622,10 +626,24 @@ def add_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
 
     db.cfgdb.set_entry('VLAN', vlan_name, vlan)
 
+    if check_sonic_dhcpv4_relay_flag :
+        if dhcpv4_relay_servers:
+            relay_entry = db.cfgdb.get_entry('DHCPV4_RELAY', vlan_name)
+        if not relay_entry:
+            relay_entry = {}
+        existing = relay_entry.get('dhcpv4_servers', [])
+        # Ensure no duplicates
+        for ip in dhcpv4_relay_servers:
+            if ip not in existing:
+                existing.append(ip)
+        relay_entry['dhcpv4_servers'] = existing
+        db.cfgdb.set_entry('DHCPV4_RELAY', vlan_name, relay_entry)
+
     if len(added_servers):
         click.echo("Added DHCP relay destination addresses {} to {}".format(added_servers, vlan_name))
         try:
-            restart_dhcp_relay_service(db)
+            ip_version = IPV4 if clicommon.ipaddress_type(ip_addr) == 4 else IPV6
+            restart_dhcp_relay_service(db, ip_version)
         except SystemExit as e:
             ctx.fail("Restart service dhcp_relay failed with error {}".format(e))
 
@@ -639,6 +657,8 @@ def del_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
 
     ctx = click.get_current_context()
 
+
+
     # Verify vlan is valid
     vlan_name = 'Vlan{}'.format(vid)
     vlan = db.cfgdb.get_entry('VLAN', vlan_name)
@@ -649,6 +669,11 @@ def del_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
     dhcp_servers = vlan.get('dhcp_servers', [])
     dhcpv6_servers = vlan.get('dhcpv6_servers', [])
 
+    # Track if we need to update DHCPV4_RELAY table
+    dhcpv4_relay_changed = False
+    relay_entry = db.cfgdb.get_entry('DHCPV4_RELAY', vlan_name)
+    dhcpv4_servers = relay_entry.get('dhcpv4_servers', []) if relay_entry else []
+
     for ip_addr in dhcp_relay_destination_ips:
         if (ip_addr not in dhcp_servers) and (ip_addr not in dhcpv6_servers):
             ctx.fail("{} is not a DHCP relay destination for {}".format(ip_addr, vlan_name))
@@ -657,6 +682,9 @@ def del_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
                 click.echo("Cannot change dhcp_relay configuration when dhcp_server feature is enabled")
                 return
             dhcp_servers.remove(ip_addr)
+            if ip_addr in dhcpv4_servers:
+                dhcpv4_servers.remove(ip_addr)
+                dhcpv4_relay_changed = True
         else:
             dhcpv6_servers.remove(ip_addr)
 
@@ -673,10 +701,20 @@ def del_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
         if 'dhcpv6_servers' in vlan.keys():
             del vlan['dhcpv6_servers']
 
+    # Update DHCPV4_RELAY table if needed
+    if check_sonic_dhcpv4_relay_flag :
+        if dhcpv4_relay_changed:
+            if len(dhcpv4_servers) == 0:
+                db.cfgdb.set_entry('DHCPV4_RELAY', vlan_name, None)
+            else:
+                relay_entry['dhcpv4_servers'] = dhcpv4_servers
+                db.cfgdb.set_entry('DHCPV4_RELAY', vlan_name, relay_entry)
+
     db.cfgdb.set_entry('VLAN', vlan_name, vlan)
     click.echo("Removed DHCP relay destination addresses {} from {}".format(dhcp_relay_destination_ips, vlan_name))
     try:
-        restart_dhcp_relay_service(db)
+        ip_version = IPV4 if clicommon.ipaddress_type(ip_addr) == 4 else IPV6
+        restart_dhcp_relay_service(db, ip_version)
     except SystemExit as e:
         ctx.fail("Restart service dhcp_relay failed with error {}".format(e))
 


### PR DESCRIPTION
**Failure:**
2025-09-02 12:22:24,880 T0000: INFO  dhcp relay ipv4 basic client ipAddr reserveSlot[Unresolved] cnt_a=0

2025-09-02 12:22:24,880 T0000: INFO  dhcp client A does not be assigned ipv4 addr set_a from dhcp server cnt_a=0


**root cause:**

After dhcp_relay helper add command vlan_table is not updated with dhcp_servers details. That command only updated the dhcpv4_table.

root@sonic:/home/admin# redis-cli -n 4

127.0.0.1:6379[4]> 

127.0.0.1:6379[4]> 

127.0.0.1:6379[4]> HGETALL "FEATURE|dhcp_relay"

"has_per_asic_scope"

"False"

"high_mem_alert"

"disabled"

"support_syslog_rate_limit"

"True"

"has_sonic_dhcpv4_relay"

"False"

"has_global_scope"

10) "True"

11) "delayed"

12) "False"

13) "set_owner"

14) "local"

15) "check_up_status"

16) "False"

17) "auto_restart"

18) "enabled"

19) "state"

20) "enabled"

127.0.0.1:6379[4]> 

127.0.0.1:6379[4]> 

127.0.0.1:6379[4]> exit

root@sonic:/home/admin# 

root@sonic:/home/admin# 

root@sonic:/home/admin# 

root@sonic:/home/admin# config dhcp_relay ipv4 helper add 10 192.168.20.10

Added DHCP relay address [192.168.20.10] to Vlan10

Restarting DHCP relay service...
root@sonic:/home/admin# redis-cli -n 4

127.0.0.1:6379[4]> 

127.0.0.1:6379[4]> 

127.0.0.1:6379[4]> 

127.0.0.1:6379[4]> HGETALL "DHCPV4_RELAY|Vlan10"

"dhcpv4_servers@"

"192.168.20.10"

127.0.0.1:6379[4]> 

127.0.0.1:6379[4]> 

127.0.0.1:6379[4]> HGETALL "VLAN|Vlan10"

"vlanid"

"10"

127.0.0.1:6379[4]> 

**Fix:**

Modified the “config dhcp_relay ipv4 helper add” cli to update vlan_table if dhcpv4 feature flag is not True.

Now mvlan cases are passed with legacy mode.

**Logs:**
[28698_pass_logs.tar.gz](https://github.com/user-attachments/files/22168980/28698_pass_logs.tar.gz)
[28698_pass_logs.txt](https://github.com/user-attachments/files/22168981/28698_pass_logs.txt)
