### PR TITLE
Addressed community review comment and cli-plugin-tests failure - DHCPv4

### DIFF
--- a/dockers/docker-dhcp-relay/cli-plugin-tests/conftest.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/conftest.py
@@ -23,8 +23,8 @@ def mock_cfgdb():
                 'dhcpv6_servers': ['fc02:2000::1']
             }
         },
-        'FEATURE': {
-            'dhcp_relay': {
+        'DEVICE_METADATA': {
+            'localhost': {
                 'has_sonic_dhcpv4_relay' : "False"
             }
         },

--- a/dockers/docker-dhcp-relay/cli-plugin-tests/mock_config.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/mock_config.py
@@ -204,8 +204,8 @@ MULTI_TEST_DATA = [
                         "max_hop_count": "5"
                     }
                 },
-                'FEATURE': {
-                    'dhcp_relay': {
+                'DEVICE_METADATA': {
+                    'localhost': {
                         'has_sonic_dhcpv4_relay' : "False"
                     }
                 }

--- a/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_dhcp_relay.py
@@ -11,6 +11,9 @@ config_dhcp_relay_add_output = """\
 Added DHCP relay address [{}] to Vlan1000
 Restarting DHCP relay service...
 """
+config_dhcp_relay_update_output = """\
+Updated DHCPv4 Servers as {} to Vlan1000
+"""
 config_dhcp_relay_del_output = """\
 Removed DHCP relay address [{}] from Vlan1000
 Restarting DHCP relay service...
@@ -104,8 +107,8 @@ IP_VER_TEST_PARAM_MAP = {
 }
 
 
-@pytest.fixture(scope="module", params=["ipv4", "ipv6"])
-def ip_version(request):
+@pytest.fixture(scope="module", params=["ipv4", "ipv4_dhcp", "ipv6"])
+def version(request):
     """
     Parametrize Ip version
 
@@ -166,13 +169,15 @@ class TestConfigDhcpRelay(object):
             assert "Error: Vlan1001 doesn't exist" in result.output
             assert mock_run_command.call_count == 0
 
-    def test_config_add_del_dhcp_relay_with_invalid_ip(self, ip_version, op):
+    def test_config_add_del_dhcp_relay_with_invalid_ip(self, version, op):
         runner = CliRunner()
-        invalid_ip = IP_VER_TEST_PARAM_MAP[ip_version]["invalid_ip"]
-
+        invalid_ip = IP_VER_TEST_PARAM_MAP[version]["invalid_ip"]
+        ip_version = "ipv6" if version == "ipv6" else "ipv4"
+        if version == "ipv4_dhvp":
+            db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'})
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             result = runner.invoke(dhcp_relay.dhcp_relay.commands[ip_version]
-                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands[IP_VER_TEST_PARAM_MAP[version]["command"]]
                                    .commands[op], ["1000", invalid_ip])
             print(result.exit_code)
             print(result.output)
@@ -180,40 +185,48 @@ class TestConfigDhcpRelay(object):
             assert "Error: {} is invalid IP address".format(invalid_ip) in result.output
             assert mock_run_command.call_count == 0
 
-    def test_config_add_dhcp_with_exist_ip(self, mock_cfgdb, ip_version):
+    def test_config_add_dhcp_with_exist_ip(self, mock_cfgdb, version):
         runner = CliRunner()
         db = Db()
         db.cfgdb = mock_cfgdb
-        exist_ip = IP_VER_TEST_PARAM_MAP[ip_version]["exist_ip"]
-
+        exist_ip = IP_VER_TEST_PARAM_MAP[version]["exist_ip"]
+        ip_version = "ipv6" if version == "ipv6" else "ipv4"
+        if version == "ipv4_dhcp":
+            db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'})
+        table = db.cfgdb.get_entry("FEATURE", "dhcp_relay")
+        if('has_sonic_dhcpv4_relay' in table and table['has_sonic_dhcpv4_relay'] == 'True'):
+            print("has_sonic_dhcpv4_relay is set")
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             result = runner.invoke(dhcp_relay.dhcp_relay.commands[ip_version]
-                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands[IP_VER_TEST_PARAM_MAP[version]["command"]]
                                    .commands["add"], ["1000", exist_ip], obj=db)
             print(result.exit_code)
             print(result.output)
             assert result.exit_code != 0
-            if ip_version == "ipv4":
-                assert "{} is already a DHCPv4 relay for Vlan1000".format(exist_ip) in result.output
+            if version == "ipv4_dhcp":
+                assert "DHCPv4 relay entry for Vlan1000 already exists. Use 'update' instead." in result.output
             else:
                 assert "{} is already a DHCP relay for Vlan1000".format(exist_ip) in result.output
             assert mock_run_command.call_count == 0
         db.cfgdb.set_entry.reset_mock()
 
-    def test_config_del_nonexist_dhcp_relay(self, mock_cfgdb, ip_version):
+    def test_config_del_nonexist_dhcp_relay(self, mock_cfgdb, version):
         runner = CliRunner()
         db = Db()
         db.cfgdb = mock_cfgdb
-        nonexist_ip = IP_VER_TEST_PARAM_MAP[ip_version]["nonexist_ip"]
+        nonexist_ip = IP_VER_TEST_PARAM_MAP[version]["nonexist_ip"]
+        ip_version = "ipv6" if version == "ipv6" else "ipv4"
+        if version == "ipv4_dhcp":
+            db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'})
 
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             result = runner.invoke(dhcp_relay.dhcp_relay.commands[ip_version]
-                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands[IP_VER_TEST_PARAM_MAP[version]["command"]]
                                    .commands["del"], ["1000", nonexist_ip], obj=db)
             print(result.exit_code)
             print(result.output)
             assert result.exit_code != 0
-            if ip_version == "ipv4":
+            if version == "ipv4_dhcp":
                 assert "Error: {} is not a DHCPv4 relay for Vlan1000".format(nonexist_ip) in result.output
             else:
                 assert "Error: {} is not a DHCP relay for Vlan1000".format(nonexist_ip) in result.output
@@ -221,56 +234,64 @@ class TestConfigDhcpRelay(object):
             assert mock_run_command.call_count == 0
         db.cfgdb.set_entry.reset_mock()
 
-    def test_config_add_del_dhcp_relay(self, mock_cfgdb, ip_version):
+    def test_config_add_del_dhcp_relay(self, mock_cfgdb, version):
         runner = CliRunner()
         db = Db()
         db.cfgdb = mock_cfgdb
-        test_ip = IP_VER_TEST_PARAM_MAP[ip_version]["ips"][0]
-        config_db_table = IP_VER_TEST_PARAM_MAP[ip_version]["table"]
+        test_ip = IP_VER_TEST_PARAM_MAP[version]["ips"][0]
+        ip_version = "ipv6" if version == "ipv6" else "ipv4"
+        config_db_table = IP_VER_TEST_PARAM_MAP[version]["table"]
 
-        if ip_version == "ipv4" :
+        if version == "ipv4_dhcp":
+            db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'})
             dhcp4_config_db_table = IP_VER_TEST_PARAM_MAP["ipv4_dhcp"]["table"]
+            op = "update"
+        else:
+            op = "add"
 
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             # add new dhcp relay
             result = runner.invoke(dhcp_relay.dhcp_relay.commands[ip_version]
-                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
-                                   .commands["add"], ["1000", test_ip], obj=db)
+                                   .commands[IP_VER_TEST_PARAM_MAP[version]["command"]]
+                                   .commands[op], ["1000", test_ip], obj=db)
             print(result.exit_code)
             print(result.output)
             assert result.exit_code == 0
-            assert result.output == config_dhcp_relay_add_output.format(test_ip)
-            if ip_version != "ipv4":
+            if version != "ipv4_dhcp":
+                assert result.output == config_dhcp_relay_add_output.format(test_ip)
                 assert db.cfgdb.get_entry(config_db_table, "Vlan1000") \
-                    == expected_dhcp_relay_add_config_db_output[ip_version]
-            assert mock_run_command.call_count == 3
+                    == expected_dhcp_relay_add_config_db_output[version]
+                assert mock_run_command.call_count == 3
 
-            if ip_version == "ipv4" :
+            if version == "ipv4_dhcp" :
+                assert result.output == config_dhcp_relay_update_output.format(test_ip)
                 expected_calls = [
+                    mock.call('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'}),
                     mock.call(dhcp4_config_db_table, "Vlan1000", expected_dhcp_relay_add_config_db_output["ipv4_dhcp"])
                 ]
 
                 assert db.cfgdb.set_entry.call_args_list == expected_calls
             else:
                 db.cfgdb.set_entry.assert_called_once_with(config_db_table, "Vlan1000",
-                                                       expected_dhcp_relay_add_config_db_output[ip_version])
+                                                       expected_dhcp_relay_add_config_db_output[version])
 
         db.cfgdb.set_entry.reset_mock()
         # del dhcp relay
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             result = runner.invoke(dhcp_relay.dhcp_relay.commands[ip_version]
-                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands[IP_VER_TEST_PARAM_MAP[version]["command"]]
                                    .commands["del"], ["1000", test_ip], obj=db)
             print(result.exit_code)
             print(result.output)
             assert result.exit_code == 0
-            assert result.output == config_dhcp_relay_del_output.format(test_ip)
-            assert mock_run_command.call_count == 3
-            if ip_version != "ipv4":
+            if version != "ipv4_dhcp":
+                assert result.output == config_dhcp_relay_del_output.format(test_ip)
                 assert db.cfgdb.get_entry(config_db_table, "Vlan1000") \
-                    == expected_dhcp_relay_del_config_db_output[ip_version]
+                    == expected_dhcp_relay_del_config_db_output[version]
+                assert mock_run_command.call_count == 3
 
-            if ip_version == "ipv4" :
+            if version == "ipv4_dhcp" :
+                assert "Removed DHCP relay address [{}] from Vlan1000".format(test_ip) in result.output
                 expected_calls = [
                     mock.call(dhcp4_config_db_table, "Vlan1000", expected_dhcp_relay_del_config_db_output["ipv4_dhcp"])
                 ]
@@ -279,7 +300,7 @@ class TestConfigDhcpRelay(object):
 
             else:
                 db.cfgdb.set_entry.assert_called_once_with(config_db_table, "Vlan1000",
-                                                           expected_dhcp_relay_del_config_db_output[ip_version])
+                                                           expected_dhcp_relay_del_config_db_output[version])
 
     def test_config_add_del_dhcp_relay_with_enable_dhcp_server(self, mock_cfgdb):
         runner = CliRunner()
@@ -311,55 +332,63 @@ class TestConfigDhcpRelay(object):
             assert result.exit_code == 0
             assert "Cannot change ipv4 dhcp_relay configuration when dhcp_server feature is enabled" in result.output
 
-    def test_config_add_del_multiple_dhcp_relay(self, mock_cfgdb, ip_version):
+    def test_config_add_del_multiple_dhcp_relay(self, mock_cfgdb, version):
         runner = CliRunner()
         db = Db()
         db.cfgdb = mock_cfgdb
-        test_ips = IP_VER_TEST_PARAM_MAP[ip_version]["ips"]
-        config_db_table = IP_VER_TEST_PARAM_MAP[ip_version]["table"]
+        test_ips = IP_VER_TEST_PARAM_MAP[version]["ips"]
+        config_db_table = IP_VER_TEST_PARAM_MAP[version]["table"]
+        ip_version = "ipv6" if version == "ipv6" else "ipv4"
 
-        if ip_version == "ipv4" :
+        if version == "ipv4_dhcp" :
+            db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'})
             dhcp4_config_db_table = IP_VER_TEST_PARAM_MAP["ipv4_dhcp"]["table"]
+            op = "update"
+        else:
+            op = "add"
 
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             # add new dhcp relay
             result = runner.invoke(dhcp_relay.dhcp_relay.commands[ip_version]
-                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
-                                   .commands["add"], ["1000"] + test_ips, obj=db)
+                                   .commands[IP_VER_TEST_PARAM_MAP[version]["command"]]
+                                   .commands[op], ["1000"] + test_ips, obj=db)
             print(result.exit_code)
             print(result.output)
             assert result.exit_code == 0
-            assert result.output == config_dhcp_relay_add_output.format(",".join(test_ips))
-            if ip_version != "ipv4":
+            if version != "ipv4_dhcp":
+                assert result.output == config_dhcp_relay_add_output.format(",".join(test_ips))
                 assert db.cfgdb.get_entry(config_db_table, "Vlan1000") \
-                    == expected_dhcp_relay_add_multi_config_db_output[ip_version]
-            assert mock_run_command.call_count == 3
+                    == expected_dhcp_relay_add_multi_config_db_output[version]
+                assert mock_run_command.call_count == 3
 
-            if ip_version == "ipv4" :
+            if version == "ipv4_dhcp" :
+                assert result.output == config_dhcp_relay_update_output.format(",".join(test_ips))
                 expected_calls = [
+                    mock.call('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'}),
                     mock.call(dhcp4_config_db_table, "Vlan1000", expected_dhcp_relay_add_multi_config_db_output["ipv4_dhcp"]),
                 ]
 
                 assert db.cfgdb.set_entry.call_args_list == expected_calls
             else:
                 db.cfgdb.set_entry.assert_called_once_with(config_db_table, "Vlan1000",
-                                                       expected_dhcp_relay_add_multi_config_db_output[ip_version])
+                                                       expected_dhcp_relay_add_multi_config_db_output[version])
 
         db.cfgdb.set_entry.reset_mock()
         # del dhcp relay
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             result = runner.invoke(dhcp_relay.dhcp_relay.commands[ip_version]
-                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands[IP_VER_TEST_PARAM_MAP[version]["command"]]
                                    .commands["del"], ["1000"] + test_ips, obj=db)
             print(result.exit_code)
             print(result.output)
             assert result.exit_code == 0
-            assert result.output == config_dhcp_relay_del_output.format(",".join(test_ips))
-            assert mock_run_command.call_count == 3
-            if ip_version != "ipv4":
+            if version != "ipv4_dhcp":
+                assert result.output == config_dhcp_relay_del_output.format(",".join(test_ips))
+                assert mock_run_command.call_count == 3
                 assert db.cfgdb.get_entry(config_db_table, "Vlan1000") \
-                    == expected_dhcp_relay_del_config_db_output[ip_version]
-            if ip_version == "ipv4":
+                    == expected_dhcp_relay_del_config_db_output[version]
+            if ip_version == "ipv4_dhcp":
+                assert "Removed DHCP relay address [{}] from Vlan1000".format(",".join(test_ip)) in result.output
                 expected_calls = [
                     mock.call(dhcp4_config_db_table, "Vlan1000", expected_dhcp_relay_del_config_db_output["ipv4_dhcp"]),
                 ]
@@ -367,25 +396,32 @@ class TestConfigDhcpRelay(object):
                 assert db.cfgdb.set_entry.call_args_list == expected_calls
             else:
                 db.cfgdb.set_entry.assert_called_once_with(config_db_table, "Vlan1000",
-                                                           expected_dhcp_relay_del_config_db_output[ip_version])
+                                                           expected_dhcp_relay_del_config_db_output[version])
 
         db.cfgdb.set_entry.reset_mock()
 
-    def test_config_add_del_duplicate_dhcp_relay(self, mock_cfgdb, ip_version, op):
+    def test_config_add_del_duplicate_dhcp_relay(self, mock_cfgdb, version, op):
         runner = CliRunner()
         db = Db()
         db.cfgdb = mock_cfgdb
-        test_ip = IP_VER_TEST_PARAM_MAP[ip_version]["ips"][0] if op == "add" \
-            else IP_VER_TEST_PARAM_MAP[ip_version]["exist_ip"]
+        test_ip = IP_VER_TEST_PARAM_MAP[version]["ips"][0] if op == "add" \
+            else IP_VER_TEST_PARAM_MAP[version]["exist_ip"]
+        ip_version = "ipv6" if version == "ipv6" else "ipv4"
+
+        if version == "ipv4_dhcp" :
+            db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'})
 
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             result = runner.invoke(dhcp_relay.dhcp_relay.commands[ip_version]
-                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands[IP_VER_TEST_PARAM_MAP[version]["command"]]
                                    .commands[op], ["1000", test_ip, test_ip], obj=db)
             print(result.exit_code)
             print(result.output)
             assert result.exit_code != 0
-            assert "Error: Find duplicate DHCP relay ip {} in {} list".format(test_ip, op) in result.output
+            if version == "ipv4_dhcp" and op == "add":
+                assert "Error: DHCPv4 relay entry for Vlan1000 already exists. Use 'update' instead." in result.output
+            else:
+                assert "Error: Find duplicate DHCP relay ip {} in {} list".format(test_ip, op) in result.output
             assert mock_run_command.call_count == 0
 
     def test_config_add_dhcp_relay_ipv6_with_non_entry(self, mock_cfgdb):

--- a/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_dhcp_relay.py
@@ -174,7 +174,7 @@ class TestConfigDhcpRelay(object):
         invalid_ip = IP_VER_TEST_PARAM_MAP[version]["invalid_ip"]
         ip_version = "ipv6" if version == "ipv6" else "ipv4"
         if version == "ipv4_dhvp":
-            db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'})
+            db.cfgdb.set_entry('DEVICE_METADATA', 'localhost', {'has_sonic_dhcpv4_relay': 'True'})
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             result = runner.invoke(dhcp_relay.dhcp_relay.commands[ip_version]
                                    .commands[IP_VER_TEST_PARAM_MAP[version]["command"]]
@@ -192,10 +192,7 @@ class TestConfigDhcpRelay(object):
         exist_ip = IP_VER_TEST_PARAM_MAP[version]["exist_ip"]
         ip_version = "ipv6" if version == "ipv6" else "ipv4"
         if version == "ipv4_dhcp":
-            db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'})
-        table = db.cfgdb.get_entry("FEATURE", "dhcp_relay")
-        if('has_sonic_dhcpv4_relay' in table and table['has_sonic_dhcpv4_relay'] == 'True'):
-            print("has_sonic_dhcpv4_relay is set")
+            db.cfgdb.set_entry('DEVICE_METADATA', 'localhost', {'has_sonic_dhcpv4_relay': 'True'})
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             result = runner.invoke(dhcp_relay.dhcp_relay.commands[ip_version]
                                    .commands[IP_VER_TEST_PARAM_MAP[version]["command"]]
@@ -217,7 +214,7 @@ class TestConfigDhcpRelay(object):
         nonexist_ip = IP_VER_TEST_PARAM_MAP[version]["nonexist_ip"]
         ip_version = "ipv6" if version == "ipv6" else "ipv4"
         if version == "ipv4_dhcp":
-            db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'})
+            db.cfgdb.set_entry('DEVICE_METADATA', 'localhost', {'has_sonic_dhcpv4_relay': 'True'})
 
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             result = runner.invoke(dhcp_relay.dhcp_relay.commands[ip_version]
@@ -243,7 +240,7 @@ class TestConfigDhcpRelay(object):
         config_db_table = IP_VER_TEST_PARAM_MAP[version]["table"]
 
         if version == "ipv4_dhcp":
-            db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'})
+            db.cfgdb.set_entry('DEVICE_METADATA', 'localhost', {'has_sonic_dhcpv4_relay': 'True'})
             dhcp4_config_db_table = IP_VER_TEST_PARAM_MAP["ipv4_dhcp"]["table"]
             op = "update"
         else:
@@ -266,7 +263,7 @@ class TestConfigDhcpRelay(object):
             if version == "ipv4_dhcp" :
                 assert result.output == config_dhcp_relay_update_output.format(test_ip)
                 expected_calls = [
-                    mock.call('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'}),
+                    mock.call('DEVICE_METADATA', 'localhost', {'has_sonic_dhcpv4_relay': 'True'}),
                     mock.call(dhcp4_config_db_table, "Vlan1000", expected_dhcp_relay_add_config_db_output["ipv4_dhcp"])
                 ]
 
@@ -341,7 +338,7 @@ class TestConfigDhcpRelay(object):
         ip_version = "ipv6" if version == "ipv6" else "ipv4"
 
         if version == "ipv4_dhcp" :
-            db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'})
+            db.cfgdb.set_entry('DEVICE_METADATA', 'localhost', {'has_sonic_dhcpv4_relay': 'True'})
             dhcp4_config_db_table = IP_VER_TEST_PARAM_MAP["ipv4_dhcp"]["table"]
             op = "update"
         else:
@@ -364,7 +361,7 @@ class TestConfigDhcpRelay(object):
             if version == "ipv4_dhcp" :
                 assert result.output == config_dhcp_relay_update_output.format(",".join(test_ips))
                 expected_calls = [
-                    mock.call('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'}),
+                    mock.call('DEVICE_METADATA', 'localhost', {'has_sonic_dhcpv4_relay': 'True'}),
                     mock.call(dhcp4_config_db_table, "Vlan1000", expected_dhcp_relay_add_multi_config_db_output["ipv4_dhcp"]),
                 ]
 
@@ -409,7 +406,7 @@ class TestConfigDhcpRelay(object):
         ip_version = "ipv6" if version == "ipv6" else "ipv4"
 
         if version == "ipv4_dhcp" :
-            db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'})
+            db.cfgdb.set_entry('DEVICE_METADATA', 'localhost', {'has_sonic_dhcpv4_relay': 'True'})
 
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             result = runner.invoke(dhcp_relay.dhcp_relay.commands[ip_version]
@@ -455,7 +452,7 @@ class TestConfigDhcpRelay(object):
         table = IP_VER_TEST_PARAM_MAP[ip_version]["table"]
 
         #set feature flag
-        db.cfgdb.set_entry("FEATURE", "dhcp_relay", {"has_sonic_dhcpv4_relay" : "True"})
+        db.cfgdb.set_entry("DEVICE_METADATA", "localhost", {"has_sonic_dhcpv4_relay" : "True"})
         db.cfgdb.set_entry("DHCPV4_RELAY", "Vlan1000", None)
 
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
@@ -499,7 +496,7 @@ class TestConfigDhcpRelay(object):
         table = IP_VER_TEST_PARAM_MAP[ip_version]["table"]
 
         #set feature flag
-        db.cfgdb.set_entry("FEATURE", "dhcp_relay", {"has_sonic_dhcpv4_relay" : "True"})
+        db.cfgdb.set_entry("DEVICE_METADATA", "localhost", {"has_sonic_dhcpv4_relay" : "True"})
 
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             # Present delete cmd should work with new feature flag enabled
@@ -521,7 +518,7 @@ class TestConfigDhcpRelay(object):
         table = IP_VER_TEST_PARAM_MAP[ip_version]["table"]
 
         #unset feature flag
-        db.cfgdb.set_entry("FEATURE", "dhcp_relay", {"has_sonic_dhcpv4_relay" : "False"})
+        db.cfgdb.set_entry("DEVICE_METADATA", "localhost", {"has_sonic_dhcpv4_relay" : "False"})
 
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
 
@@ -555,7 +552,7 @@ class TestConfigDhcpRelay(object):
         table = IP_VER_TEST_PARAM_MAP[ip_version]["table"]
 
         #set feature flag
-        db.cfgdb.set_entry("FEATURE", "dhcp_relay", {"has_sonic_dhcpv4_relay":"True"})
+        db.cfgdb.set_entry("DEVICE_METADATA", "localhost", {"has_sonic_dhcpv4_relay":"True"})
 
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             # Updating parameters also should work with new feature flag set
@@ -587,7 +584,7 @@ class TestConfigDhcpRelay(object):
         table = IP_VER_TEST_PARAM_MAP[ip_version]["table"]
 
         #unset feature flag
-        db.cfgdb.set_entry("FEATURE", "dhcp_relay", {"has_sonic_dhcpv4_relay":"False"})
+        db.cfgdb.set_entry("DEVICE_METADATA", "localhost", {"has_sonic_dhcpv4_relay":"False"})
 
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             # Update cmd is available only for new feature, it should NOT work when flag is disabled

--- a/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_vlan_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_vlan_dhcp_relay.py
@@ -129,9 +129,9 @@ class TestConfigVlanDhcpRelay(object):
         db = Db()
         db.cfgdb = mock_cfgdb
         if mode == "isc":
-           db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'False'})
+           db.cfgdb.set_entry('DEVICE_METADATA', 'localhost', {'has_sonic_dhcpv4_relay': 'False'})
         elif mode == "new":
-            db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'})
+            db.cfgdb.set_entry('DEVICE_METADATA', 'localhost', {'has_sonic_dhcpv4_relay': 'True'})
         # add new relay dest
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             result = runner.invoke(dhcp_relay.vlan_dhcp_relay.commands["add"],
@@ -143,14 +143,14 @@ class TestConfigVlanDhcpRelay(object):
                 assert result.output == config_vlan_add_dhcp_relay_output
                 assert mock_run_command.call_count == 3
                 expected_calls = [
-                    mock.call('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'False'}),
+                    mock.call('DEVICE_METADATA', 'localhost', {'has_sonic_dhcpv4_relay': 'False'}),
                     mock.call('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1', '192.0.0.100']})
                 ]
                 db.cfgdb.set_entry.assert_has_calls(expected_calls)
             elif mode == "new":
                 assert "Added DHCP relay destination addresses ['192.0.0.100'] to Vlan1000" in result.output
                 expected_calls = [
-                    mock.call('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'}),
+                    mock.call('DEVICE_METADATA', 'localhost', {'has_sonic_dhcpv4_relay': 'True'}),
                     #mock.call('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1', '192.0.0.100']}),
                     mock.call('DHCPV4_RELAY', 'Vlan1000', {'dhcpv4_servers': ['192.0.0.1', '192.0.0.100']})
                 ]
@@ -158,9 +158,9 @@ class TestConfigVlanDhcpRelay(object):
 
         db.cfgdb.set_entry.reset_mock()
         if mode == "isc":
-           db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'False'})
+           db.cfgdb.set_entry('DEVICE_METADATA', 'localhost', {'has_sonic_dhcpv4_relay': 'False'})
         elif mode == "new":
-            db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'})
+            db.cfgdb.set_entry('DEVICE_METADATA', 'localhost', {'has_sonic_dhcpv4_relay': 'True'})
 
         # del relay dest
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
@@ -173,14 +173,14 @@ class TestConfigVlanDhcpRelay(object):
                 assert result.output == config_vlan_del_dhcp_relay_output
                 assert mock_run_command.call_count == 3
                 expected_calls = [
-                    mock.call('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'False'}),
+                    mock.call('DEVICE_METADATA', 'localhost', {'has_sonic_dhcpv4_relay': 'False'}),
                     mock.call('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1']})
                 ]
                 db.cfgdb.set_entry.assert_has_calls(expected_calls)
             elif mode == "new":
                 assert "Removed DHCP relay destination addresses ('192.0.0.100',) from Vlan1000" in result.output
                 expected_calls = [
-                    mock.call('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'}),
+                    mock.call('DEVICE_METADATA', 'localhost', {'has_sonic_dhcpv4_relay': 'True'}),
                     #mock.call(('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1']}),
                     mock.call('DHCPV4_RELAY', 'Vlan1000', {'dhcpv4_servers': ['192.0.0.1']})
                 ]

--- a/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_vlan_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_vlan_dhcp_relay.py
@@ -42,6 +42,19 @@ Removed DHCP relay destination addresses ('fc02:2000::1', 'fc02:2000::2', 'fc02:
 Restarting DHCP relay service...
 """
 
+@pytest.fixture(scope="module", params=["isc", "new"])
+def mode(request):
+    """
+    Parametrize dhcp mode
+
+    Args:
+        request: pytest request object
+
+    Returns:
+        dhcp mode needed for test case
+    """
+    return request.param
+
 class TestConfigVlanDhcpRelay(object):
     def test_plugin_registration(self):
         cli = mock.MagicMock()
@@ -111,11 +124,14 @@ class TestConfigVlanDhcpRelay(object):
             assert "192.0.0.1 is already a DHCP relay destination for Vlan1000" in result.output
             assert mock_run_command.call_count == 0
 
-    def test_config_vlan_add_del_dhcp_relay_dest(self, mock_cfgdb):
+    def test_config_vlan_add_del_dhcp_relay_dest(self, mock_cfgdb, mode):
         runner = CliRunner()
         db = Db()
         db.cfgdb = mock_cfgdb
-
+        if mode == "isc":
+           db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'False'})
+        elif mode == "new":
+            db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'})
         # add new relay dest
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             result = runner.invoke(dhcp_relay.vlan_dhcp_relay.commands["add"],
@@ -123,11 +139,28 @@ class TestConfigVlanDhcpRelay(object):
             print(result.exit_code)
             print(result.output)
             assert result.exit_code == 0
-            assert result.output == config_vlan_add_dhcp_relay_output
-            assert mock_run_command.call_count == 3
-            db.cfgdb.set_entry.assert_called_once_with('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1', '192.0.0.100']})
+            if mode == "isc":
+                assert result.output == config_vlan_add_dhcp_relay_output
+                assert mock_run_command.call_count == 3
+                expected_calls = [
+                    mock.call('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'False'}),
+                    mock.call('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1', '192.0.0.100']})
+                ]
+                db.cfgdb.set_entry.assert_has_calls(expected_calls)
+            elif mode == "new":
+                assert "Added DHCP relay destination addresses ['192.0.0.100'] to Vlan1000" in result.output
+                expected_calls = [
+                    mock.call('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'}),
+                    #mock.call('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1', '192.0.0.100']}),
+                    mock.call('DHCPV4_RELAY', 'Vlan1000', {'dhcpv4_servers': ['192.0.0.1', '192.0.0.100']})
+                ]
+                db.cfgdb.set_entry.assert_has_calls(expected_calls)
 
         db.cfgdb.set_entry.reset_mock()
+        if mode == "isc":
+           db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'False'})
+        elif mode == "new":
+            db.cfgdb.set_entry('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'})
 
         # del relay dest
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
@@ -136,9 +169,22 @@ class TestConfigVlanDhcpRelay(object):
             print(result.exit_code)
             print(result.output)
             assert result.exit_code == 0
-            assert result.output == config_vlan_del_dhcp_relay_output
-            assert mock_run_command.call_count == 3
-            db.cfgdb.set_entry.assert_called_once_with('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1']})
+            if mode == "isc":
+                assert result.output == config_vlan_del_dhcp_relay_output
+                assert mock_run_command.call_count == 3
+                expected_calls = [
+                    mock.call('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'False'}),
+                    mock.call('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1']})
+                ]
+                db.cfgdb.set_entry.assert_has_calls(expected_calls)
+            elif mode == "new":
+                assert "Removed DHCP relay destination addresses ('192.0.0.100',) from Vlan1000" in result.output
+                expected_calls = [
+                    mock.call('FEATURE', 'dhcp_relay', {'has_sonic_dhcpv4_relay': 'True'}),
+                    #mock.call(('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1']}),
+                    mock.call('DHCPV4_RELAY', 'Vlan1000', {'dhcpv4_servers': ['192.0.0.1']})
+                ]
+                db.cfgdb.set_entry.assert_has_calls(expected_calls)
 
     def test_config_vlan_add_del_dhcpv6_relay_dest(self, mock_cfgdb):
         runner = CliRunner()

--- a/dockers/docker-dhcp-relay/cli-plugin-tests/test_show_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/test_show_dhcp_relay.py
@@ -184,7 +184,7 @@ def test_show_multi_dhcp_relay(test_name, test_data, fs):
     table = config_db.get_table(IP_VER_TEST_PARAM_MAP[ip_version]["table"])
 
     if ip_version == "ipv4_dhcp":
-        config_db.set_entry("FEATURE", "dhcp_relay", {"has_sonic_dhcpv4_relay" : "True"})
+        config_db.set_entry("DEVICE_METADATA", "localhost", {"has_sonic_dhcpv4_relay" : "True"})
         result = show.get_dhcpv4_relay_data_with_header(table, IP_VER_TEST_PARAM_MAP[ip_version]["entry"])
     else:
         result = show.get_dhcp_relay_data_with_header(table, IP_VER_TEST_PARAM_MAP[ip_version]["entry"])

--- a/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
@@ -599,11 +599,14 @@ def add_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
     # Verify all ip addresses are valid and not exist in DB
     dhcp_servers = vlan.get('dhcp_servers', [])
     dhcpv6_servers = vlan.get('dhcpv6_servers', [])
+    # Track if we need to update DHCPV4_RELAY table
+    relay_entry = db.cfgdb.get_entry('DHCPV4_RELAY', vlan_name)
+    dhcpv4_servers = relay_entry.get('dhcpv4_servers', []) if relay_entry else []
 
     for ip_addr in dhcp_relay_destination_ips:
         try:
             ipaddress.ip_address(ip_addr)
-            if (ip_addr in dhcp_servers) or (ip_addr in dhcpv6_servers):
+            if (ip_addr in dhcp_servers) or (ip_addr in dhcpv6_servers) or (ip_addr in dhcpv4_servers):
                 click.echo("{} is already a DHCP relay destination for {}".format(ip_addr, vlan_name))
                 continue
             if clicommon.ipaddress_type(ip_addr) == 4:
@@ -613,31 +616,24 @@ def add_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
                 if not check_sonic_dhcpv4_relay_flag(db):
                     dhcp_servers.append(ip_addr)
                 else:
-                    dhcpv4_relay_servers.append(ip_addr)
+                    dhcpv4_servers.append(ip_addr)
             else:
                 dhcpv6_servers.append(ip_addr)
             added_servers.append(ip_addr)
         except Exception:
             ctx.fail('{} is invalid IP address'.format(ip_addr))
 
-    # Append new dhcp servers to config DB
-    if len(dhcp_servers):
-        vlan['dhcp_servers'] = dhcp_servers
-    if len(dhcpv6_servers):
-        vlan['dhcpv6_servers'] = dhcpv6_servers
-
     ip_version = IPV4 if clicommon.ipaddress_type(ip_addr) == 4 else IPV6
     if ip_version == IPV4 and check_sonic_dhcpv4_relay_flag(db):
-        if dhcpv4_relay_servers:
-            relay_entry = db.cfgdb.get_entry('DHCPV4_RELAY', vlan_name)
-        existing = relay_entry.get('dhcpv4_servers', [])
-        # Ensure no duplicates
-        for ip in dhcpv4_relay_servers:
-            if ip not in existing:
-                existing.append(ip)
-        relay_entry['dhcpv4_servers'] = existing
+        if len(dhcpv4_servers):
+            relay_entry['dhcpv4_servers'] = dhcpv4_servers
         db.cfgdb.set_entry('DHCPV4_RELAY', vlan_name, relay_entry)
     else:
+        # Append new dhcp servers to config DB
+        if len(dhcp_servers):
+            vlan['dhcp_servers'] = dhcp_servers
+        if len(dhcpv6_servers):
+            vlan['dhcpv6_servers'] = dhcpv6_servers
         db.cfgdb.set_entry('VLAN', vlan_name, vlan)
 
     if len(added_servers):
@@ -690,19 +686,6 @@ def del_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
         else:
             dhcpv6_servers.remove(ip_addr)
 
-    # Update dhcp servers to config DB
-    if len(dhcp_servers):
-        vlan['dhcp_servers'] = dhcp_servers
-    else:
-        if 'dhcp_servers' in vlan.keys():
-            del vlan['dhcp_servers']
-
-    if len(dhcpv6_servers):
-        vlan['dhcpv6_servers'] = dhcpv6_servers
-    else:
-        if 'dhcpv6_servers' in vlan.keys():
-            del vlan['dhcpv6_servers']
-
     ip_version = IPV4 if clicommon.ipaddress_type(ip_addr) == 4 else IPV6
     # Update DHCPV4_RELAY table if needed
     if ip_version == IPV4 and check_sonic_dhcpv4_relay_flag(db) :
@@ -713,6 +696,18 @@ def del_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
                 relay_entry['dhcpv4_servers'] = dhcpv4_servers
                 db.cfgdb.set_entry('DHCPV4_RELAY', vlan_name, relay_entry)
     else:
+        # Update dhcp servers to config DB
+        if len(dhcp_servers):
+            vlan['dhcp_servers'] = dhcp_servers
+        else:
+            if 'dhcp_servers' in vlan.keys():
+                del vlan['dhcp_servers']
+
+        if len(dhcpv6_servers):
+            vlan['dhcpv6_servers'] = dhcpv6_servers
+        else:
+            if 'dhcpv6_servers' in vlan.keys():
+                del vlan['dhcpv6_servers']
         db.cfgdb.set_entry('VLAN', vlan_name, vlan)
     click.echo("Removed DHCP relay destination addresses {} from {}".format(dhcp_relay_destination_ips, vlan_name))
     try:

--- a/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
@@ -587,7 +587,7 @@ def add_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
     ctx = click.get_current_context()
     added_servers = []
     dhcpv4_relay_servers = []
-
+    relay_entry = {}
 
 
     # Verify vlan is valid
@@ -610,8 +610,10 @@ def add_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
                 if is_dhcp_server_enabled(db):
                     click.echo("Cannot change dhcp_relay configuration when dhcp_server feature is enabled")
                     return
-                dhcp_servers.append(ip_addr)
-                dhcpv4_relay_servers.append(ip_addr)
+                if not check_sonic_dhcpv4_relay_flag(db):
+                    dhcp_servers.append(ip_addr)
+                else:
+                    dhcpv4_relay_servers.append(ip_addr)
             else:
                 dhcpv6_servers.append(ip_addr)
             added_servers.append(ip_addr)
@@ -624,13 +626,10 @@ def add_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
     if len(dhcpv6_servers):
         vlan['dhcpv6_servers'] = dhcpv6_servers
 
-    db.cfgdb.set_entry('VLAN', vlan_name, vlan)
-
-    if check_sonic_dhcpv4_relay_flag :
+    ip_version = IPV4 if clicommon.ipaddress_type(ip_addr) == 4 else IPV6
+    if ip_version == IPV4 and check_sonic_dhcpv4_relay_flag(db):
         if dhcpv4_relay_servers:
             relay_entry = db.cfgdb.get_entry('DHCPV4_RELAY', vlan_name)
-        if not relay_entry:
-            relay_entry = {}
         existing = relay_entry.get('dhcpv4_servers', [])
         # Ensure no duplicates
         for ip in dhcpv4_relay_servers:
@@ -638,11 +637,12 @@ def add_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
                 existing.append(ip)
         relay_entry['dhcpv4_servers'] = existing
         db.cfgdb.set_entry('DHCPV4_RELAY', vlan_name, relay_entry)
+    else:
+        db.cfgdb.set_entry('VLAN', vlan_name, vlan)
 
     if len(added_servers):
         click.echo("Added DHCP relay destination addresses {} to {}".format(added_servers, vlan_name))
         try:
-            ip_version = IPV4 if clicommon.ipaddress_type(ip_addr) == 4 else IPV6
             restart_dhcp_relay_service(db, ip_version)
         except SystemExit as e:
             ctx.fail("Restart service dhcp_relay failed with error {}".format(e))
@@ -675,16 +675,18 @@ def del_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
     dhcpv4_servers = relay_entry.get('dhcpv4_servers', []) if relay_entry else []
 
     for ip_addr in dhcp_relay_destination_ips:
-        if (ip_addr not in dhcp_servers) and (ip_addr not in dhcpv6_servers):
+        if (ip_addr not in dhcp_servers) and (ip_addr not in dhcpv6_servers) and (ip_addr not in dhcpv4_servers):
             ctx.fail("{} is not a DHCP relay destination for {}".format(ip_addr, vlan_name))
         if clicommon.ipaddress_type(ip_addr) == 4:
             if is_dhcp_server_enabled(db):
                 click.echo("Cannot change dhcp_relay configuration when dhcp_server feature is enabled")
                 return
-            dhcp_servers.remove(ip_addr)
-            if ip_addr in dhcpv4_servers:
-                dhcpv4_servers.remove(ip_addr)
-                dhcpv4_relay_changed = True
+            if not check_sonic_dhcpv4_relay_flag(db):
+                dhcp_servers.remove(ip_addr)
+            else:
+                if ip_addr in dhcpv4_servers:
+                    dhcpv4_servers.remove(ip_addr)
+                    dhcpv4_relay_changed = True
         else:
             dhcpv6_servers.remove(ip_addr)
 
@@ -701,19 +703,19 @@ def del_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
         if 'dhcpv6_servers' in vlan.keys():
             del vlan['dhcpv6_servers']
 
+    ip_version = IPV4 if clicommon.ipaddress_type(ip_addr) == 4 else IPV6
     # Update DHCPV4_RELAY table if needed
-    if check_sonic_dhcpv4_relay_flag :
+    if ip_version == IPV4 and check_sonic_dhcpv4_relay_flag(db) :
         if dhcpv4_relay_changed:
             if len(dhcpv4_servers) == 0:
                 db.cfgdb.set_entry('DHCPV4_RELAY', vlan_name, None)
             else:
                 relay_entry['dhcpv4_servers'] = dhcpv4_servers
                 db.cfgdb.set_entry('DHCPV4_RELAY', vlan_name, relay_entry)
-
-    db.cfgdb.set_entry('VLAN', vlan_name, vlan)
+    else:
+        db.cfgdb.set_entry('VLAN', vlan_name, vlan)
     click.echo("Removed DHCP relay destination addresses {} from {}".format(dhcp_relay_destination_ips, vlan_name))
     try:
-        ip_version = IPV4 if clicommon.ipaddress_type(ip_addr) == 4 else IPV6
         restart_dhcp_relay_service(db, ip_version)
     except SystemExit as e:
         ctx.fail("Restart service dhcp_relay failed with error {}".format(e))

--- a/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
@@ -14,7 +14,7 @@ DHCPV4_RELAY_TABLE = "DHCPV4_RELAY"
 
 
 def check_sonic_dhcpv4_relay_flag(db):
-    table = db.cfgdb.get_entry("FEATURE", "dhcp_relay")
+    table = db.cfgdb.get_entry("DEVICE_METADATA", "localhost")
     if('has_sonic_dhcpv4_relay' in table and table['has_sonic_dhcpv4_relay'] == 'True'):
         return True
     return False
@@ -53,7 +53,7 @@ def restart_dhcp_relay_service(db, ip_version):
     Restart dhcp_relay service
     """
     if(ip_version == IPV4 and check_sonic_dhcpv4_relay_flag(db)):
-        # if 'has_sonic_dhcpv4_relay' flag is present in FEATURE['dhcp_relay] and is 'true'
+        # if 'has_sonic_dhcpv4_relay' flag is present in DEVICE_METADATA['localhost'] and is 'true'
         return
     click.echo("Restarting DHCP relay service...")
     clicommon.run_command(['systemctl', 'stop', 'dhcp_relay'], display_cmd=False)

--- a/dockers/docker-dhcp-relay/cli/show/plugins/show_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/show/plugins/show_dhcp_relay.py
@@ -52,7 +52,7 @@ def check_sonic_dhcpv4_relay_flag():
         return
 
     config_db.connect()
-    table = config_db.get_entry("FEATURE", "dhcp_relay")
+    table = config_db.get_entry("DEVICE_METADATA", "localhost")
     if('has_sonic_dhcpv4_relay' in table and table['has_sonic_dhcpv4_relay'] == 'True'):
         return True
     return False

--- a/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
@@ -49,7 +49,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-{% if 'has_sonic_dhcpv4_relay' in FEATURE['dhcp_relay'] and FEATURE['dhcp_relay']['has_sonic_dhcpv4_relay'] == 'True' %}
+{% if 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' %}
 dependent_startup_wait_for=dhcp4relay:running
 {% else %}
 dependent_startup_wait_for=isc-dhcpv4-relay-{{ vlan_name }}:running

--- a/dockers/docker-dhcp-relay/dhcp-relay.programs.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.programs.j2
@@ -1,6 +1,6 @@
 [group:dhcp-relay]
 programs=dhcprelayd
-{%- if 'has_sonic_dhcpv4_relay' in FEATURE['dhcp_relay'] and FEATURE['dhcp_relay']['has_sonic_dhcpv4_relay'] == 'True' %}
+{%- if 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' %}
 {%- set relay_for_ipv6 = { 'flag': False } %}
 {%- set add_preceding_comma = { 'flag': True } %}
 {% for vlan_name in VLAN_INTERFACE %}

--- a/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
+++ b/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
@@ -48,7 +48,7 @@ dependent_startup_wait_for=rsyslogd:running
 {# Count how many VLANs require a DHCP relay agent... #}
 {% set ipv4_num_relays = { 'count': 0 } %}
 {% set ipv6_num_relays = { 'count': 0 } %}
-{% if 'has_sonic_dhcpv4_relay' in FEATURE['dhcp_relay'] and FEATURE['dhcp_relay']['has_sonic_dhcpv4_relay'] == 'True' %}
+{% if 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' %}
 {% set _dummy = ipv4_num_relays.update({'count': ipv4_num_relays.count + 1}) %}
 {% endif %}
 {% for vlan_name in VLAN_INTERFACE %}
@@ -67,7 +67,7 @@ dependent_startup_wait_for=rsyslogd:running
 {% set relay_for_ipv4 = { 'flag': False } %}
 {% set relay_for_ipv6 = { 'flag': False } %}
 {# Decide the dhcpv4 relay agent based on the feature config #}
-{% if 'has_sonic_dhcpv4_relay' in FEATURE['dhcp_relay'] and FEATURE['dhcp_relay']['has_sonic_dhcpv4_relay'] == 'True' %}
+{% if 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' %}
 {% include 'dhcpv4-sonic-relay.agents.j2' %}
 {% include 'dhcpv6-relay.agents.j2' %}
 {% include 'dhcp-relay.monitors.j2' %}
@@ -85,7 +85,7 @@ dependent_startup_wait_for=rsyslogd:running
 {% endif %}
 {% endif %}
 {% else %}
-{% if 'has_sonic_dhcpv4_relay' in FEATURE['dhcp_relay'] and FEATURE['dhcp_relay']['has_sonic_dhcpv4_relay'] == 'True' %}
+{% if 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' %}
 {% include 'dhcpv4-sonic-relay.agents.j2' %}
 {% endif %}
 {% endif %}

--- a/src/sonic-config-engine/tests/dhcp-sonic-relay-disabled-sample.json
+++ b/src/sonic-config-engine/tests/dhcp-sonic-relay-disabled-sample.json
@@ -14,10 +14,13 @@
             "has_per_asic_scope": "False",
             "high_mem_alert": "disabled",
             "set_owner": "local",
-            "has_sonic_dhcpv4_relay": "False",
             "state": "enabled",
             "support_syslog_rate_limit": "True"
         }
-
+    },
+    "DEVICE_METADATA": {
+        "localhost": {
+            "has_sonic_dhcpv4_relay": "False"
+        }
     }
 }

--- a/src/sonic-config-engine/tests/dhcp-sonic-relay-enabled-sample.json
+++ b/src/sonic-config-engine/tests/dhcp-sonic-relay-enabled-sample.json
@@ -14,10 +14,13 @@
             "has_per_asic_scope": "False",
             "high_mem_alert": "disabled",
             "set_owner": "local",
-            "has_sonic_dhcpv4_relay": "True",
             "state": "enabled",
             "support_syslog_rate_limit": "True"
         }
-
+    },
+    "DEVICE_METADATA": {
+	"localhost": {
+            "has_sonic_dhcpv4_relay": "True"
+	}
     }
 }

--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py
@@ -108,8 +108,8 @@ class DhcpRelayd(object):
             set([FEATURE_CHECKER, DHCP_SERVER_CHECKER])
         self._disable_checkers(checkers_to_be_disabled)
 
-        feature_table = self.db_connector.get_config_db_table("FEATURE")
-        if feature_table.get("dhcp_relay", {}).get("has_sonic_dhcpv4_relay", "False") == "False":
+        device_metadata_table = self.db_connector.get_config_db_table("DEVICE_METADATA")
+        if device_metadata_table.get("localhost", {}).get("has_sonic_dhcpv4_relay", "False") == "False":
            self._start_dhcrelay_process(dhcp_interfaces, dhcp_server_ip, force_kill)
 
         # TODO dhcpmon is not ready for count packet for dhcp_server, hence comment invoke it for now

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -317,6 +317,12 @@ module sonic-device_metadata {
                     description "Enable syslog with OS version feature.";
                     default "false";
                 }
+
+                leaf has_sonic_dhcpv4_relay {
+                     description "This configuration controls the dhcpv4 relay process";
+                     type stypes:boolean_type;
+                     default "false";
+                }
             }
             /* end of container localhost */
         }

--- a/src/sonic-yang-models/yang-models/sonic-feature.yang
+++ b/src/sonic-yang-models/yang-models/sonic-feature.yang
@@ -117,13 +117,6 @@ module sonic-feature{
                     type stypes:boolean_type;
                     default "false";
                 }
-
-                leaf has_sonic_dhcpv4_relay {
-                     when "../name = 'dhcp_relay'";
-                     description "This configuration controls the dhcpv4 relay process";
-                     type stypes:boolean_type;
-                     default "false";
-                }
             }
         }
     }


### PR DESCRIPTION
**Fixed  CI/CD compilation failure.**

**Modified the config vlan dhcp_relay add/del:**
Before:
With has_sonic_dhcpv4_relay flag it will update both DHCPV4_RELAY table and VLAN table.
Without has_sonic_dhcpv4_relay flag it will update VLAN table.
With has_sonic_dhcpv4_relay flag if we are adding ipv6 address its updating DHCPV4_RELAY table.

After:
With has_sonic_dhcpv4_relay flag it will update DHCPV4_RELAY table.
Without has_sonic_dhcpv4_relay flag it will update VLAN table.
with has_sonic_dhcpv4_relay flag if we are adding ipv6 address its updating only VLAN table.

Compilation passed logs:
[docker-dhcp-relay.gz.log](https://github.com/user-attachments/files/22268227/docker-dhcp-relay.gz.log)

**Addressed community review comment:**

Moved "has_sonic_dhcpv4_relay" flag from FEATURE["dhcp_relay"] to DEVICE_METADATA["localhost"] table

https://github.com/sonic-net/sonic-dhcp-relay/pull/67

**spytest logs:**

[26700_dhcpv4_new_design_logs.zip](https://github.com/user-attachments/files/22494082/26700_dhcpv4_new_design_logs.zip)


[ISC_26700_logs.zip](https://github.com/user-attachments/files/22494087/ISC_26700_logs.zip)
